### PR TITLE
improve BinaryNbtWriter performance

### DIFF
--- a/docs/helium-server/nbt/ref/inbttoken.md
+++ b/docs/helium-server/nbt/ref/inbttoken.md
@@ -32,3 +32,15 @@ public Byte[] Name { get; }
 ~~~
 
 Declares the name of this token. May be ommitted for the root `NbtCompoundToken` or tokens inside a `NbtListToken`.
+
+## Methods
+
+~~~cs
+public abstract static void WriteNameless(Stream stream, INbtToken token);
+~~~
+
+Defines a way to write a nameless instance of this token to a stream. This is not implemented in `NbtCompoundToken`, `NbtListToken` and `NbtEndToken`
+
+## See also
+
+- [`NbtCompoundToken`](./nbtcompoundtoken)

--- a/src/Helium.Nbt/INbtToken.cs
+++ b/src/Helium.Nbt/INbtToken.cs
@@ -1,6 +1,7 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -23,4 +24,10 @@ public interface INbtToken
 	/// Name of this Named Binary Data Token.
 	/// </summary>
 	public Byte[] Name { get; }
+
+	/// <summary>
+	/// Writes a token of this type to the passed stream.
+	/// </summary>
+	/// <exception cref="InvalidCastException"/>
+	public abstract static void WriteNameless(Stream stream, INbtToken token);
 }

--- a/src/Helium.Nbt/NbtBigEndianInt32ArrayToken.cs
+++ b/src/Helium.Nbt/NbtBigEndianInt32ArrayToken.cs
@@ -1,9 +1,12 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
 using Helium.Nbt.Internal;
@@ -94,6 +97,17 @@ public sealed class NbtBigEndianInt32ArrayToken : IValuedComplexNbtToken<Int32Bi
 	public void AddChild(Int32BigEndian token)
 	{
 		this.Add(token);
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtBigEndianInt32ArrayToken t = (NbtBigEndianInt32ArrayToken)token;
+		Span<Byte> buffer = stackalloc Byte[4];
+
+		BinaryPrimitives.WriteInt32BigEndian(buffer, t.Count);
+
+		stream.Write(buffer);
+		stream.Write(MemoryMarshal.Cast<Int32BigEndian, Byte>(CollectionsMarshal.AsSpan(t.Elements)));
 	}
 }
 

--- a/src/Helium.Nbt/NbtBigEndianInt64ArrayToken.cs
+++ b/src/Helium.Nbt/NbtBigEndianInt64ArrayToken.cs
@@ -1,9 +1,12 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
 using Helium.Nbt.Internal;
@@ -94,5 +97,16 @@ public sealed class NbtBigEndianInt64ArrayToken : IValuedComplexNbtToken<Int64Bi
 	public void AddChild(Int64BigEndian token)
 	{
 		this.Add(token);
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtBigEndianInt64ArrayToken t = (NbtBigEndianInt64ArrayToken)token;
+		Span<Byte> buffer = stackalloc Byte[4];
+
+		BinaryPrimitives.WriteInt32BigEndian(buffer, t.Count);
+
+		stream.Write(buffer);
+		stream.Write(MemoryMarshal.Cast<Int64BigEndian, Byte>(CollectionsMarshal.AsSpan(t.Elements)));
 	}
 }

--- a/src/Helium.Nbt/NbtByteArrayToken.cs
+++ b/src/Helium.Nbt/NbtByteArrayToken.cs
@@ -1,8 +1,10 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 
@@ -92,5 +94,16 @@ public sealed class NbtByteArrayToken : IValuedComplexNbtToken<Byte>, IList<Byte
 	public void AddChild(Byte token)
 	{
 		this.Add(token);
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtByteArrayToken t = (NbtByteArrayToken)token;
+		Span<Byte> buffer = stackalloc Byte[4];
+
+		BinaryPrimitives.WriteInt32BigEndian(buffer, t.Count);
+
+		stream.Write(buffer);
+		stream.Write(t.Elements.ToArray());
 	}
 }

--- a/src/Helium.Nbt/NbtByteToken.cs
+++ b/src/Helium.Nbt/NbtByteToken.cs
@@ -1,6 +1,7 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -21,5 +22,11 @@ public record struct NbtByteToken : IValuedNbtToken<Byte>
 	{
 		this.Name = name;
 		this.Value = value;
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtByteToken t = (NbtByteToken)token;
+		stream.WriteByte(t.Value);
 	}
 }

--- a/src/Helium.Nbt/NbtCompoundToken.cs
+++ b/src/Helium.Nbt/NbtCompoundToken.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -51,4 +52,8 @@ public sealed class NbtCompoundToken : IComplexNbtToken, ICollection
 	{
 		throw new NotImplementedException();
 	}
+
+	[Obsolete("Not in use. Use BinaryNbtWriter#WriteCompoundToken(NbtCompoundToken, Boolean) instead.")]
+	public static void WriteNameless(Stream stream, INbtToken token)
+		=> throw new NotImplementedException("Use BinaryNbtWriter#WriteCompoundToken(NbtCompoundToken, Boolean) instead");
 }

--- a/src/Helium.Nbt/NbtDoubleToken.cs
+++ b/src/Helium.Nbt/NbtDoubleToken.cs
@@ -1,6 +1,8 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -21,5 +23,15 @@ public record struct NbtDoubleToken : IValuedNbtToken<Double>
 	{
 		this.Name = name;
 		this.Value = value;
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtDoubleToken t = (NbtDoubleToken)token;
+		Span<Byte> buffer = stackalloc Byte[8];
+
+		BinaryPrimitives.WriteDoubleBigEndian(buffer, t.Value);
+
+		stream.Write(buffer);
 	}
 }

--- a/src/Helium.Nbt/NbtEndToken.cs
+++ b/src/Helium.Nbt/NbtEndToken.cs
@@ -1,6 +1,7 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -14,4 +15,8 @@ public sealed class NbtEndToken : INbtToken
 	public static Int32 Length => 0;
 
 	public Byte[] Name => null!;
+
+	[Obsolete("This token cannot be written.")]
+	public static void WriteNameless(Stream stream, INbtToken token)
+		=> throw new NotImplementedException("NbtEndTokens cannot be written and therefore cannot be written nameless.");
 }

--- a/src/Helium.Nbt/NbtInt16Token.cs
+++ b/src/Helium.Nbt/NbtInt16Token.cs
@@ -1,6 +1,8 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -21,5 +23,15 @@ public record struct NbtInt16Token : IValuedNbtToken<Int16>
 	{
 		this.Name = name;
 		this.Value = value;
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtInt16Token t = (NbtInt16Token)token;
+		Span<Byte> buffer = stackalloc Byte[2];
+
+		BinaryPrimitives.WriteInt16BigEndian(buffer, t.Value);
+
+		stream.Write(buffer);
 	}
 }

--- a/src/Helium.Nbt/NbtInt32ArrayToken.cs
+++ b/src/Helium.Nbt/NbtInt32ArrayToken.cs
@@ -1,8 +1,10 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 
@@ -92,6 +94,23 @@ public sealed class NbtInt32ArrayToken : IValuedComplexNbtToken<Int32>, IList<In
 	public void AddChild(Int32 token)
 	{
 		this.Add(token);
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtInt32ArrayToken t = (NbtInt32ArrayToken)token;
+		Span<Byte> buffer = stackalloc Byte[4];
+
+		BinaryPrimitives.WriteInt32BigEndian(buffer, t.Count);
+
+		stream.Write(buffer);
+
+		foreach(Int32 i in t.Elements)
+		{
+			BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+
+			stream.Write(buffer);
+		}
 	}
 }
 

--- a/src/Helium.Nbt/NbtInt32Token.cs
+++ b/src/Helium.Nbt/NbtInt32Token.cs
@@ -1,6 +1,8 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -21,5 +23,15 @@ public record struct NbtInt32Token : IValuedNbtToken<Int32>
 	{
 		this.Name = name;
 		this.Value = value;
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtInt32Token t = (NbtInt32Token)token;
+		Span<Byte> buffer = stackalloc Byte[4];
+
+		BinaryPrimitives.WriteInt32BigEndian(buffer, t.Value);
+
+		stream.Write(buffer);
 	}
 }

--- a/src/Helium.Nbt/NbtInt64ArrayToken.cs
+++ b/src/Helium.Nbt/NbtInt64ArrayToken.cs
@@ -1,8 +1,10 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 
@@ -92,5 +94,22 @@ public sealed class NbtInt64ArrayToken : IValuedComplexNbtToken<Int64>, IList<In
 	public void AddChild(Int64 token)
 	{
 		this.Add(token);
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtInt64ArrayToken t = (NbtInt64ArrayToken)token;
+		Span<Byte> buffer = stackalloc Byte[4], buffer2 = stackalloc Byte[8];
+
+		BinaryPrimitives.WriteInt32BigEndian(buffer, t.Count);
+
+		stream.Write(buffer);
+
+		foreach(Int64 i in t.Elements)
+		{
+			BinaryPrimitives.WriteInt64BigEndian(buffer2, i);
+
+			stream.Write(buffer2);
+		}
 	}
 }

--- a/src/Helium.Nbt/NbtInt64Token.cs
+++ b/src/Helium.Nbt/NbtInt64Token.cs
@@ -1,6 +1,8 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -21,5 +23,15 @@ public record struct NbtInt64Token : IValuedNbtToken<Int64>
 	{
 		this.Name = name;
 		this.Value = value;
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtInt64Token t = (NbtInt64Token)token;
+		Span<Byte> buffer = stackalloc Byte[8];
+
+		BinaryPrimitives.WriteInt64BigEndian(buffer, t.Value);
+
+		stream.Write(buffer);
 	}
 }

--- a/src/Helium.Nbt/NbtListToken.cs
+++ b/src/Helium.Nbt/NbtListToken.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -100,4 +101,8 @@ public sealed class NbtListToken :
 	{
 		throw new NotImplementedException();
 	}
+
+	[Obsolete("Lists should not be nested, therefore this method does not need support")]
+	public static void WriteNameless(Stream stream, INbtToken token)
+		=> throw new NotImplementedException("Lists should not be nested.");
 }

--- a/src/Helium.Nbt/NbtSingleToken.cs
+++ b/src/Helium.Nbt/NbtSingleToken.cs
@@ -1,6 +1,8 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
+using System.IO;
 using System.Runtime.Versioning;
 
 /// <summary>
@@ -21,5 +23,15 @@ public record struct NbtSingleToken : IValuedNbtToken<Single>
 	{
 		this.Name = name;
 		this.Value = value;
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtSingleToken t = (NbtSingleToken)token;
+		Span<Byte> buffer = stackalloc Byte[4];
+
+		BinaryPrimitives.WriteSingleBigEndian(buffer, t.Value);
+
+		stream.Write(buffer);
 	}
 }

--- a/src/Helium.Nbt/NbtStringToken.cs
+++ b/src/Helium.Nbt/NbtStringToken.cs
@@ -1,6 +1,8 @@
 ﻿namespace Helium.Nbt;
 
 using System;
+using System.Buffers.Binary;
+using System.IO;
 using System.Runtime.Versioning;
 using System.Text;
 
@@ -28,5 +30,16 @@ public sealed class NbtStringToken : IValuedNbtToken<String>
 	{
 		this.Name = name;
 		this.Value = value;
+	}
+
+	public static void WriteNameless(Stream stream, INbtToken token)
+	{
+		NbtStringToken t = (NbtStringToken)token;
+		Span<Byte> buffer = stackalloc Byte[2];
+
+		BinaryPrimitives.WriteInt16BigEndian(buffer, (Int16)t.Value.Length);
+
+		stream.Write(buffer);
+		stream.Write(Encoding.UTF8.GetBytes(t.Value));
 	}
 }

--- a/src/Helium.Nbt/Serialization/BinaryNbtWriter.cs
+++ b/src/Helium.Nbt/Serialization/BinaryNbtWriter.cs
@@ -189,7 +189,7 @@ public class BinaryNbtWriter
 
 		foreach(INbtToken v in list.Content)
 		{
-			this.WriteNamelessToken(v);
+			this.WriteNamelessToken(v, list.ListTokenType);
 		}
 	}
 
@@ -294,48 +294,56 @@ public class BinaryNbtWriter
 	/// <summary>
 	/// Writes any nameless <see cref="INbtToken"/> to the current stream.
 	/// </summary>
-	public void WriteNamelessToken(INbtToken token)
+	public void WriteNamelessToken(INbtToken token, NbtTokenType type)
 	{
-		switch(token)
+		switch(type)
 		{
-			case NbtByteToken t:
-				this.WriteByte(t.Value);
+			case NbtTokenType.Byte:
+				NbtByteToken.WriteNameless(this.DataStream, token);
 				break;
-			case NbtInt16Token t:
-				this.WriteInt16(t.Value);
+			case NbtTokenType.Short:
+				NbtInt16Token.WriteNameless(this.DataStream, token);
 				break;
-			case NbtInt32Token t:
-				this.WriteInt32(t.Value);
+			case NbtTokenType.Int:
+				NbtInt32Token.WriteNameless(this.DataStream, token);
 				break;
-			case NbtInt64Token t:
-				this.WriteInt64(t.Value);
+			case NbtTokenType.Long:
+				NbtInt64Token.WriteNameless(this.DataStream, token);
 				break;
-			case NbtSingleToken t:
-				this.WriteSingle(t.Value);
+			case NbtTokenType.Float:
+				NbtSingleToken.WriteNameless(this.DataStream, token);
 				break;
-			case NbtDoubleToken t:
-				this.WriteDouble(t.Value);
+			case NbtTokenType.Double:
+				NbtDoubleToken.WriteNameless(this.DataStream, token);
 				break;
-			case NbtByteArrayToken t:
-				this.WriteByteArray(t.Elements);
+			case NbtTokenType.ByteArray:
+				NbtByteArrayToken.WriteNameless(this.DataStream, token);
 				break;
-			case NbtStringToken t:
-				this.WriteString(t.Value);
+			case NbtTokenType.String:
+				NbtStringToken.WriteNameless(this.DataStream, token);
 				break;
-			case NbtCompoundToken t:
+			case NbtTokenType.Compound:
+				NbtCompoundToken t = (NbtCompoundToken)token;
 				this.WriteCompoundToken(t, false);
 				break;
-			case NbtInt32ArrayToken t:
-				this.WriteInt32Array(t.Elements);
+			case NbtTokenType.IntArray:
+				if(token is NbtInt32ArrayToken i32)
+				{
+					NbtInt32ArrayToken.WriteNameless(this.DataStream, i32);
+				} 
+				else if(token is NbtBigEndianInt32ArrayToken bei32) // its a big endian token
+				{
+					NbtBigEndianInt32ArrayToken.WriteNameless(this.DataStream, bei32);
+				}
 				break;
-			case NbtBigEndianInt32ArrayToken t:
-				this.WriteInt32ArrayBigEndian(t.Elements);
-				break;
-			case NbtInt64ArrayToken t:
-				this.WriteInt64Array(t.Elements);
-				break;
-			case NbtBigEndianInt64ArrayToken t:
-				this.WriteInt64ArrayBigEndian(t.Elements);
+			case NbtTokenType.LongArray:
+				if(token is NbtInt64ArrayToken i64)
+				{
+					NbtInt64ArrayToken.WriteNameless(this.DataStream, i64);
+				} else if(token is NbtBigEndianInt64ArrayToken bei64) // its a big endian token
+				{
+					NbtBigEndianInt64ArrayToken.WriteNameless(this.DataStream, bei64);
+				}
 				break;
 		}
 	}


### PR DESCRIPTION
Improves `BinaryNbtWriter` performance by removing pattern matching from writing `NbtListToken` as far as feasible. 